### PR TITLE
Remove 'Salir' button from header in Vivienda A Primero A page

### DIFF
--- a/viviendas/a-primero-a.html
+++ b/viviendas/a-primero-a.html
@@ -330,7 +330,6 @@
                 <a href="../index.html" class="logo">Barsant <span>Promociones</span></a>
                 <div class="header-buttons">
                     <a href="../index.html#contact" class="cta-button">Solicitar Información</a>
-                    <a href="#" id="logout-btn" class="logout-button"><i class="fas fa-sign-out-alt"></i> Salir</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The 'Salir' (logout) button was present in the header of the specific page for 'Vivienda A Primero A' (`viviendas/a-primero-a.html`). This commit removes the button as per your request.