### PR TITLE
Add Firestore import instructions without bundled data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 # Archivos de utilidad
 src/js/generate-hash.js
 
+# Local Firestore data files
+data/*.json

--- a/README.md
+++ b/README.md
@@ -78,3 +78,18 @@ Los servicios para interactuar con APIs y manejar lógica de negocio:
 - **base/**: Contiene reset.css, variables.css para consistencia visual
 - **components/**: Estilos específicos de componentes
 - **pages/**: Estilos específicos de páginas
+
+## Importar datos a Firestore
+
+La carpeta `data/` debe contener los archivos `viviendas.json`, `cocheras.json` y `trasteros.json`, que no se incluyen en el repositorio. Crea estos archivos localmente para cargarlos en Firestore.
+
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_CLIENT_EMAIL`
+- `FIREBASE_PRIVATE_KEY`
+
+Una vez definidas, ejecutar:
+
+```bash
+node scripts/importData.js
+```
+

--- a/scripts/importData.js
+++ b/scripts/importData.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+const admin = require('firebase-admin');
+
+const {
+  FIREBASE_PROJECT_ID,
+  FIREBASE_CLIENT_EMAIL,
+  FIREBASE_PRIVATE_KEY
+} = process.env;
+
+if (!FIREBASE_PROJECT_ID || !FIREBASE_CLIENT_EMAIL || !FIREBASE_PRIVATE_KEY) {
+  console.error('Missing Firebase credentials.');
+  process.exit(1);
+}
+
+admin.initializeApp({
+  credential: admin.credential.cert({
+    projectId: FIREBASE_PROJECT_ID,
+    clientEmail: FIREBASE_CLIENT_EMAIL,
+    privateKey: FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n')
+  })
+});
+
+const db = admin.firestore();
+
+async function importCollection(fileName, collectionName) {
+  const filePath = path.join(__dirname, '..', 'data', fileName);
+  const items = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const batch = db.batch();
+  items.forEach(item => {
+    const docRef = db.collection(collectionName).doc();
+    batch.set(docRef, item);
+  });
+  await batch.commit();
+  console.log(`Imported ${items.length} items into ${collectionName}`);
+}
+
+async function run() {
+  await importCollection('viviendas.json', 'viviendas');
+  await importCollection('cocheras.json', 'cocheras');
+  await importCollection('trasteros.json', 'trasteros');
+  console.log('Import completed');
+}
+
+run().catch(err => {
+  console.error('Error importing data:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ignore local JSON files used for Firestore import
- keep empty `data/` directory for local files
- update README explaining the JSON files are not included

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6841d0367d5c832d9af51fd5abcba931